### PR TITLE
Crc 1

### DIFF
--- a/dev/public/pages/buttons.jsx
+++ b/dev/public/pages/buttons.jsx
@@ -10,6 +10,7 @@ class DocButtons extends Component {
 
     const propTypesTitle = '// Prop Types';
     const propTypes = `
+  className: PropTypes.string,
   text: PropTypes.string.isRequired,
   color: PropTypes.oneOf([
     'default',

--- a/src/components/meta/Button.jsx
+++ b/src/components/meta/Button.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 
 class MetaButton extends Component {
   render() {
-    const buttonClassName = `btn btn-${this.props.color} ${this.props.size
-      ? `btn-${this.props.size}`
-      : ''} ${this.props.btnStyle ? `btn-${this.props.btnStyle}` : ''}`;
+    const buttonClassName = `btn btn-${this.props.color} 
+    ${this.props.size ? `btn-${this.props.size}` : ''} 
+    ${this.props.className ? `${this.props.className}` : ''}
+    ${this.props.btnStyle ? `btn-${this.props.btnStyle}` : ''}`;
 
     return (
       <button
@@ -22,6 +23,7 @@ class MetaButton extends Component {
 }
 
 MetaButton.defaultProps = {
+  className: '',
   color: 'default',
   size: '',
   btnStyle: '',
@@ -32,6 +34,7 @@ MetaButton.defaultProps = {
 };
 
 MetaButton.propTypes = {
+  className: PropTypes.string,
   text: PropTypes.string.isRequired,
   type: PropTypes.string,
   onClick: PropTypes.func,


### PR DESCRIPTION
Buttons will now be able to take in additional class names that haven't already been preset by the metaphor classes by simply keying in to "className"