### PR TITLE
ChatBubble p tags now have a unique key to them. CRC-14

### DIFF
--- a/src/components/web/ChatBubble.jsx
+++ b/src/components/web/ChatBubble.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { generate as shortIdGenerate } from 'shortid';
 import './sass/_chatBubble.scss';
 
 const MetaChatBubble = (props) => {
@@ -7,7 +8,7 @@ const MetaChatBubble = (props) => {
   const alignmentStyle = `${props.className} ${props.receiver
     ? 'bubble-container bubble-container--left'
     : 'bubble-container bubble-container--right'}`;
-  const paragraphs = props.text.split(/\\n|\n/).map(sentence => <p>{sentence}</p>);
+  const paragraphs = props.text.split(/\\n|\n/).map(sentence => <p key={shortIdGenerate()}>{sentence}</p>);
   return (
     <div className={alignmentStyle}>
       <div className={bubbleStyle}>


### PR DESCRIPTION
P tags, or any element for that matter, need to have a unique key to them when you render a list of them or have an array of them being generated.